### PR TITLE
Much clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+Pulsar-Simint
+=============
+
+Pulsar-Simint is a library providing Pulsar bindings for the Simint integral
+library.
+
+Contents
+========
+- [Obtaining Pulsar-Simint](#obtaining-pulsar-simint)
+- [Building Pulsar-Simint](#building-pulsar-simint)
+
+
+Obtaining Pulsar-Simint
+-----------------------
+
+Pulsar-Simint can be obtained from the official GitHub repository, located
+:link:[here](https://github.com/pulsar-chem/Pulsar-Simint).  To obtain the
+source use the usual git clone command:
+
+```.sh
+git clone https://github.com/pulsar-chem/Pulsar-Simint
+```
+At the time of writing, Pulsar-Simint will not build Simint for you.  Thus
+you will also have to obtain and build Simint.  Simint can be downloaded from
+:link:[here](http://www.bennyp.org/research/simint/).  Documentation for how to
+build Simint is also located there.
+
+Building Pulsar-Simint
+----------------------
+
+Building Pulsar-Simint is similar to building most other Pulsar supermodules.
+Configuring is done via the CMake command:
+
+```.sh
+cmake -Bbuild -H. -DOPTION1=Value1 -DOPTION2=...
+```
+
+Pulsar-Simint tries to honor most CMake variables.  Some influential variables
+are:
+| Option Name            | Default                 | Description |
+|:----------------------:|:-----------------------:|-------------|
+| CMAKE_C_COMPILER       | N/A | This is the C compiler to use.  By default CMake will try to find a C compiler on your system. Typically this means it will find  `/bin/gcc`.  |
+| CMAKE_CXX_COMPILER     | N/A | Similar to above, except for the C++ compiler. |
+| CMAKE_C_FLAGS          | N/A | Any additional flags you want to pass to the C compiler. |
+| CMAKE_CXX_FLAGS | N/A | Any additional flags you want to pass to the C++ compiler. |
+| CMAKE_BUILD_TYPE | Release | Can be used to enable debug builds.  Valid choices are: `Release`, `Debug`, or `RelWithDebInfo`. |
+| CMAKE_PREFIX_PATH | N/A | Used to tell CMake additional places to look for dependencies.  CMake will look for executables in `CMAKE_PREFIX_PATH/bin/`, libraries in `CMAKE_PREFIX_PATH/lib/`, *etc*. |
+| CMAKE_INSTALL_PREFIX | `/usr` | The root directory where the final project will be installed following usual GNU conventions.  *i.e.* libraries will be installed to `CMAKE_INSTALL_PREFIX/lib`, header files to `CMAKE_INSTALL_PREFIX/include`, *etc.* |
+
+Additionally, you will need to tell Pulsar-Simint where Simint is located.  To
+this end Pulsar-Simint defines the option `SIMINT_PATH` which should point to
+the root directory of the Simint installation tree.
+
+After a successful configuration the remainder of the build should be possible
+via:
+```.sh
+cd build && make
+make install
+```

--- a/SimintERI.cpp
+++ b/SimintERI.cpp
@@ -4,24 +4,22 @@
 
 #include "SimintERI.hpp"
 
-#include "simint/simint_init.h"
-#include "simint/eri/eri.h"
+#include "simint/simint.h"
 
+using namespace pulsar;
 
-using namespace pulsar::output;
-using namespace pulsar::exception;
-using namespace pulsar::system;
-using namespace pulsar::datastore;
-
-
+//This is what gaussian_shell is replaced by
+using SimintShell_t=simint_shell;
+//This is what multishell_pair is replaced by
+using SimintPair=simint_multi_shellpair;
 
 static
-gaussian_shell ToSimintShell(const BasisSetShell & shell, int igen)
+SimintShell_t ToSimintShell(const BasisSetShell & shell, int igen)
 {
     size_t nprim = shell.n_primitives();
 
-    gaussian_shell gs;
-    allocate_gaussian_shell(nprim, &gs);
+    SimintShell_t gs;
+    simint_allocate_shell(nprim, &gs);
     gs.nprim = nprim;
     gs.am = shell.general_am(igen);
     gs.x = shell.get_coord(0);
@@ -33,84 +31,98 @@ gaussian_shell ToSimintShell(const BasisSetShell & shell, int igen)
     std::copy(alphas, alphas + nprim, gs.alpha);
     std::copy(coefs, coefs + nprim, gs.coef);
 
-    normalize_gaussian_shells(1, &gs);
+    simint_normalize_shells(1, &gs);
 
     return gs;
 }
 
 
-uint64_t SimintERI::calculate_(size_t shell1, size_t shell2,
-                               size_t shell3, size_t shell4,
-                               double * outbuffer, size_t bufsize)
+double *SimintERI::calculate_(size_t shell1, size_t shell2,
+                               size_t shell3, size_t shell4)
 {
     const BasisSetShell & sh1 = bs1_.shell(shell1);
     const BasisSetShell & sh2 = bs2_.shell(shell2);
     const BasisSetShell & sh3 = bs3_.shell(shell3);
     const BasisSetShell & sh4 = bs4_.shell(shell4);
 
-    size_t nfunc = sh1.n_functions() * sh2.n_functions() * sh3.n_functions() * sh4.n_functions();
-
-    if(bufsize < nfunc)
-        throw GeneralException("Buffer to small for ERI", "bufsize", bufsize, "nfunc", nfunc);
-
     double * srcptr = sourcework_;
 
     for(size_t ng1 = 0; ng1 < sh1.n_general_contractions(); ng1++)
     {
-        gaussian_shell gs1 = ToSimintShell(sh1, ng1);
+        SimintShell_t gs1 = ToSimintShell(sh1, ng1);
         const size_t ncart1 = n_cartesian_gaussian(sh1.general_am(ng1));
 
         for(size_t ng2 = 0; ng2 < sh2.n_general_contractions(); ng2++)
         {
-            gaussian_shell gs2 = ToSimintShell(sh2, ng2);
+            SimintShell_t gs2 = ToSimintShell(sh2, ng2);
             const size_t ncart2 = n_cartesian_gaussian(sh2.general_am(ng2));
-            multishell_pair bra_pair = create_multishell_pair(1, &gs1, 1, &gs2); 
+            SimintPair bra_pair;
+            simint_initialize_multi_shellpair(&bra_pair);
+            simint_create_multi_shellpair(1, &gs1, 1, &gs2, &bra_pair, 0);
 
             for(size_t ng3 = 0; ng3 < sh3.n_general_contractions(); ng3++)
             {
-                gaussian_shell gs3 = ToSimintShell(sh3, ng3);
+                SimintShell_t gs3 = ToSimintShell(sh3, ng3);
                 const size_t ncart3 = n_cartesian_gaussian(sh3.general_am(ng3));
 
                 for(size_t ng4 = 0; ng4 < sh4.n_general_contractions(); ng4++)
                 {
                     // form the shell pair info
-                    gaussian_shell gs4 = ToSimintShell(sh4, ng4);
-                    multishell_pair ket_pair = create_multishell_pair(1, &gs3, 1, &gs4); 
+                    SimintShell_t gs4 = ToSimintShell(sh4, ng4);
+                    SimintPair ket_pair;
+                    simint_initialize_multi_shellpair(&ket_pair);
+                    simint_create_multi_shellpair(1, &gs3, 1, &gs4,&ket_pair,0);
                     const size_t ncart4 = n_cartesian_gaussian(sh4.general_am(ng4));
                     const size_t ncart = ncart1 * ncart2 * ncart3 * ncart4;
 
-                    size_t ncalc = simint_compute_eri(bra_pair, ket_pair, srcptr);
+                    size_t ncalc = simint_compute_eri(&bra_pair, &ket_pair, 0.0, srcptr);
 
-                    free_gaussian_shell(gs4);
-                    free_multishell_pair(ket_pair);
+                    simint_free_shell(&gs4);
+                    simint_free_multi_shellpair(&ket_pair);
 
                     srcptr += ncalc * ncart;
                 }
 
-                free_gaussian_shell(gs3);
+                simint_free_shell(&gs3);
             }
 
-            free_gaussian_shell(gs2);
-            free_multishell_pair(bra_pair);
+            simint_free_shell(&gs2);
+            simint_free_multi_shellpair(&bra_pair);
         }
 
-        free_gaussian_shell(gs1);
+        simint_free_shell(&gs1);
     }
 
 
-    CartesianToSpherical_4Center(sh1, sh2, sh3, sh4, sourcework_, outbuffer, transformwork_, 1);
+    CartesianToSpherical_4Center(sh1, sh2, sh3, sh4, sourcework_, buffer_.data(), transformwork_, 1);
 
-    return nfunc;
+    return buffer_.data();
+}
+
+//Returns 3 multichoose l, i.e. the number of Cartesian Gaussians for angular
+//momentum l
+static size_t multichoose(size_t l)
+{
+    if(l==0)return 1;
+    else if(l==1)return 3;
+    else if(l==2)return 6;
+    else if(l==3)return 10;
+    else if(l==4)return 15;
+    else if(l==5)return 21;
+    else if(l==6)return 28;
+    else if(l==7)return 36;
+    else
+      throw PulsarException("Simint only supports up to angular momentum l==7");
 }
 
 
 void SimintERI::initialize_(unsigned int deriv,
-                            const Wavefunction & wfn,
+                            const Wavefunction &,
                             const BasisSet & bs1, const BasisSet & bs2,
                             const BasisSet & bs3, const BasisSet & bs4)
 {
     if(deriv != 0)
-        throw NotYetImplementedException("Not Yet Implemented: Simint with deriv != 0");
+        throw PulsarException("Not Yet Implemented: Simint with deriv != 0");
 
     // initialize the simint library
     simint_init();
@@ -122,7 +134,6 @@ void SimintERI::initialize_(unsigned int deriv,
     bs3_ = bs3;
     bs4_ = bs4;
 
-
     // determine work sizes
     size_t maxsize1 = bs1_.max_property(n_cartesian_gaussian_for_shell_am);
     size_t maxsize2 = bs2_.max_property(n_cartesian_gaussian_for_shell_am);
@@ -130,14 +141,15 @@ void SimintERI::initialize_(unsigned int deriv,
     size_t maxsize4 = bs4_.max_property(n_cartesian_gaussian_for_shell_am);
     size_t transformwork_size = maxsize1*maxsize2*maxsize3*maxsize4;
     
-    maxsize1 =  bs1_.max_property(n_cartesian_gaussian_in_shell);
-    maxsize2 =  bs2_.max_property(n_cartesian_gaussian_in_shell);
-    maxsize3 =  bs3_.max_property(n_cartesian_gaussian_in_shell);
-    maxsize4 =  bs4_.max_property(n_cartesian_gaussian_in_shell);
+    maxsize1 =  multichoose(*bs1_.all_am().rbegin());
+    maxsize2 =  multichoose(*bs2_.all_am().rbegin());
+    maxsize3 =  multichoose(*bs3_.all_am().rbegin());
+    maxsize4 =  multichoose(*bs4_.all_am().rbegin());
     size_t sourcework_size = maxsize1*maxsize2*maxsize3*maxsize4;
 
     work_.resize(sourcework_size+transformwork_size);
     sourcework_ = work_.data();
-    transformwork_ = sourcework_ + sourcework_size;   
+    transformwork_ = sourcework_ + sourcework_size;
+    buffer_.resize(transformwork_size);
 }
 

--- a/SimintERI.hpp
+++ b/SimintERI.hpp
@@ -1,8 +1,8 @@
-#ifndef _GUARD_SIMINTRI_HPP_
-#define _GUARD_SIMINTRI_HPP_
+#pragma once
 
 #include <pulsar/modulebase/FourCenterIntegral.hpp>
 #include <pulsar/system/BasisSet.hpp>
+#include "simint/simint.h"
 
 class SimintERI : public pulsar::FourCenterIntegral
 {
@@ -33,14 +33,20 @@ public:
     virtual double* calculate_(size_t shell1, size_t shell2,
                                size_t shell3, size_t shell4);
 
+    typedef std::vector<simint_multi_shellpair> ShellPairVec;
+    typedef std::vector<simint_shell> ShellVec;
+
 private:
-    pulsar::BasisSet bs1_, bs2_, bs3_, bs4_;
-    std::vector<double> buffer_;
-    std::vector<double> work_;
-    double * sourcework_;
-    double * transformwork_;
 
+
+    std::array<pulsar::BasisSet,4> bs_;
+    std::array<std::shared_ptr<const ShellVec>,4> shells_;
+    std::array<std::shared_ptr<const ShellPairVec>,2> single_spairs_;
+    std::array<std::shared_ptr<const ShellPairVec>,2> multi_spairs_;
+
+    double * buffer_;
+    double * sharedwork_;
+    double * allwork_;
+    double * source_full_;
+    double * tformbuf_full_;
 };
-
-
-#endif

--- a/SimintERI.hpp
+++ b/SimintERI.hpp
@@ -1,29 +1,41 @@
 #ifndef _GUARD_SIMINTRI_HPP_
 #define _GUARD_SIMINTRI_HPP_
 
-#include <pulsar/modulebase/TwoElectronIntegral.hpp>
+#include <pulsar/modulebase/FourCenterIntegral.hpp>
 #include <pulsar/system/BasisSet.hpp>
 
-class SimintERI : public pulsar::modulebase::TwoElectronIntegral
+class SimintERI : public pulsar::FourCenterIntegral
 {
 public:
-    using pulsar::modulebase::TwoElectronIntegral::TwoElectronIntegral;
+    using pulsar::FourCenterIntegral::FourCenterIntegral;
+
+    HashType my_hash_(unsigned int deriv,
+                      const pulsar::Wavefunction&,
+                      const pulsar::BasisSet& bs1,
+                      const pulsar::BasisSet& bs2,
+                      const pulsar::BasisSet& bs3,
+                      const pulsar::BasisSet& bs4)
+    {
+        return bphash::hash_to_string(bs1.my_hash())+
+                bphash::hash_to_string(bs2.my_hash())+
+                bphash::hash_to_string(bs3.my_hash())+
+                bphash::hash_to_string(bs4.my_hash())+
+                std::to_string(deriv);
+    }
 
     virtual void initialize_(unsigned int deriv,
-                             const pulsar::datastore::Wavefunction & wfn,
-                             const pulsar::system::BasisSet & bs1,
-                             const pulsar::system::BasisSet & bs2,
-                             const pulsar::system::BasisSet & bs3,
-                             const pulsar::system::BasisSet & bs4);
+                             const pulsar::Wavefunction & wfn,
+                             const pulsar::BasisSet & bs1,
+                             const pulsar::BasisSet & bs2,
+                             const pulsar::BasisSet & bs3,
+                             const pulsar::BasisSet & bs4);
 
-
-    virtual uint64_t calculate_(size_t shell1, size_t shell2,
-                                size_t shell3, size_t shell4,
-                                double * outbuffer, size_t bufsize);
+    virtual double* calculate_(size_t shell1, size_t shell2,
+                               size_t shell3, size_t shell4);
 
 private:
-    pulsar::system::BasisSet bs1_, bs2_, bs3_, bs4_;
-
+    pulsar::BasisSet bs1_, bs2_, bs3_, bs4_;
+    std::vector<double> buffer_;
     std::vector<double> work_;
     double * sourcework_;
     double * transformwork_;

--- a/creator.cpp
+++ b/creator.cpp
@@ -1,6 +1,6 @@
 #include "SimintERI.hpp"
 
-using pulsar::modulemanager::ModuleCreationFuncs;
+using pulsar::ModuleCreationFuncs;
 
 
 extern "C" {


### PR DESCRIPTION
I wanted to start playing with Simint so I set out to update it's API.  Things I did and am pretty sure I did right:
1. Removed the old nested Pulsar namespaces.
2. Changed the base class from `TwoElectronIntegral` to `FourCenterIntegral`
3. Added a buffer for the integrals and switched the return to it.
4. Added the required `my_hash_` function. (this will need updated to match any options that get added).

Remaining issues/things to check:
1. I'm not sure what the differences are between `sourcework` and `transformwork` allocations. I get the pointer arithmetic, more specifically I don't get what the difference between `n_cartesian_gaussian_for_shell_am` and `n_cartesian_gaussian_in_shell` is.  My changes assume the latter is the maximum number of Cartesian basis functions in any one shell in the basis set.
2. The Simint structs that were there no longer exist.  I assume I got the mapping correct.
3. There are now screening parameters to pass to Simint.  These need to be given option names.